### PR TITLE
Bugfix/bagdata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [not yet released]
+
+### Fixed
+- in webGL with brotli-compression for the binary-tiles the accompanying data-files could not be found.
+
 
 ## [0.1.1] - 17-05-2022
 

--- a/Packages/Netherlands3D/Core/Runtime/Scripts/TileSystem/BinaryMeshLayer.cs
+++ b/Packages/Netherlands3D/Core/Runtime/Scripts/TileSystem/BinaryMeshLayer.cs
@@ -204,6 +204,11 @@ namespace Netherlands3D.TileSystem
 			container.SetActive(isEnabled);
 
 			mesh = BinaryMeshConversion.ReadBinaryMesh(binaryMeshData, out int[] submeshIndices);
+
+#if !UNITY_EDITOR && UNITY_WEBGL
+			if(brotliCompressedExtention.Length>0)
+				source = source.replace(brotliCompressedExtention,"");
+#endif
 			mesh.name = source;
 			container.AddComponent<MeshFilter>().sharedMesh = mesh;
 


### PR DESCRIPTION
bagID-data could not be found in webgl because the brotli-extention was included in the meshname and not removed when looking for the data