### PR TITLE
Update SunTime.cs

### DIFF
--- a/Packages/Netherlands3D/Sun/Runtime/Scripts/SunTime.cs
+++ b/Packages/Netherlands3D/Sun/Runtime/Scripts/SunTime.cs
@@ -151,7 +151,7 @@ namespace Netherlands3D.Sun
 
         public void SetTimeSpeed(float multiplicationFactor) {
             timeSpeed = Math.Clamp(timeSpeed * multiplicationFactor, 1, 10000);
-            sendAnimationSpeed.Invoke(timeSpeed);
+            sendAnimationSpeed?.Invoke(timeSpeed);
         }
 
         private void Start()
@@ -194,7 +194,7 @@ namespace Netherlands3D.Sun
 
             time = time.AddSeconds(timeSpeed * Time.deltaTime);
             if (frameStep==0) {
-                sendDateTime.Invoke(time);
+                sendDateTime?.Invoke(time);
                 SetPosition();
             }
             frameStep = (frameStep + 1) % frameSteps;


### PR DESCRIPTION
Resolved the bug: "if no DateTime event is placed into the Sun object, it throws errors on Update()" It now uses null-propagation to check if it can be Invoked