### PR TITLE
order timelinedata before loading

### DIFF
--- a/Packages/Netherlands3D/Timeline/Runtime/Scripts/Timeline/TimelineUI.cs
+++ b/Packages/Netherlands3D/Timeline/Runtime/Scripts/Timeline/TimelineUI.cs
@@ -213,6 +213,7 @@ namespace Netherlands3D.Timeline
         public void SetData(TimelineData timelineData)
         {
             this.timelineData = timelineData;
+            this.timelineData.OrderTimePeriods();
             LoadData();
         }
 


### PR DESCRIPTION
order timelinedata before loading, required because the ordered list is used to load/draw data