### PR TITLE
Conserve memory by downloading textures "non-readable"

### DIFF
--- a/Packages/Netherlands3D/Core/Runtime/Renderer/UniversalRenderPipelineAsset_Renderer.asset
+++ b/Packages/Netherlands3D/Core/Runtime/Renderer/UniversalRenderPipelineAsset_Renderer.asset
@@ -24,9 +24,6 @@ MonoBehaviour:
       PassNames: []
     overrideMaterial: {fileID: 0}
     overrideMaterialPassIndex: 0
-    overrideShader: {fileID: 0}
-    overrideShaderPassIndex: 0
-    overrideMode: 1
     overrideDepthState: 0
     depthCompareFunction: 4
     enableWrite: 1
@@ -71,7 +68,6 @@ MonoBehaviour:
     samplingPS: {fileID: 4800000, guid: 04c410c9937594faa893a11dceb85f7e, type: 3}
     stencilDeferredPS: {fileID: 4800000, guid: e9155b26e1bc55942a41e518703fe304, type: 3}
     fallbackErrorPS: {fileID: 4800000, guid: e6e9a19c3678ded42a3bc431ebef7dbd, type: 3}
-    fallbackLoadingPS: {fileID: 4800000, guid: 7f888aff2ac86494babad1c2c5daeee2, type: 3}
     materialErrorPS: {fileID: 4800000, guid: 5fd9a8feb75a4b5894c241777f519d4e, type: 3}
     coreBlitPS: {fileID: 4800000, guid: 93446b5c5339d4f00b85c159e1159b7c, type: 3}
     coreBlitColorAndDepthPS: {fileID: 4800000, guid: d104b2fc1ca6445babb8e90b0758136b, type: 3}
@@ -83,7 +79,7 @@ MonoBehaviour:
     m_Bits: 1079
   m_TransparentLayerMask:
     serializedVersion: 2
-    m_Bits: 311
+    m_Bits: 55
   m_DefaultStencilState:
     overrideStencilState: 0
     stencilReference: 0
@@ -96,6 +92,8 @@ MonoBehaviour:
   m_DepthPrimingMode: 0
   m_CopyDepthMode: 0
   m_AccurateGbufferNormals: 0
+  m_ClusteredRendering: 0
+  m_TileSize: 32
   m_IntermediateTextureMode: 1
 --- !u!114 &5356184961483977060
 MonoBehaviour:
@@ -121,9 +119,6 @@ MonoBehaviour:
       PassNames: []
     overrideMaterial: {fileID: 0}
     overrideMaterialPassIndex: 0
-    overrideShader: {fileID: 0}
-    overrideShaderPassIndex: 0
-    overrideMode: 1
     overrideDepthState: 0
     depthCompareFunction: 4
     enableWrite: 1
@@ -163,9 +158,6 @@ MonoBehaviour:
       PassNames: []
     overrideMaterial: {fileID: 0}
     overrideMaterialPassIndex: 0
-    overrideShader: {fileID: 0}
-    overrideShaderPassIndex: 0
-    overrideMode: 1
     overrideDepthState: 0
     depthCompareFunction: 4
     enableWrite: 1

--- a/Packages/Netherlands3D/Core/Runtime/Renderer/UniversalRenderPipelineAsset_Renderer.asset
+++ b/Packages/Netherlands3D/Core/Runtime/Renderer/UniversalRenderPipelineAsset_Renderer.asset
@@ -24,6 +24,9 @@ MonoBehaviour:
       PassNames: []
     overrideMaterial: {fileID: 0}
     overrideMaterialPassIndex: 0
+    overrideShader: {fileID: 0}
+    overrideShaderPassIndex: 0
+    overrideMode: 1
     overrideDepthState: 0
     depthCompareFunction: 4
     enableWrite: 1
@@ -68,6 +71,7 @@ MonoBehaviour:
     samplingPS: {fileID: 4800000, guid: 04c410c9937594faa893a11dceb85f7e, type: 3}
     stencilDeferredPS: {fileID: 4800000, guid: e9155b26e1bc55942a41e518703fe304, type: 3}
     fallbackErrorPS: {fileID: 4800000, guid: e6e9a19c3678ded42a3bc431ebef7dbd, type: 3}
+    fallbackLoadingPS: {fileID: 4800000, guid: 7f888aff2ac86494babad1c2c5daeee2, type: 3}
     materialErrorPS: {fileID: 4800000, guid: 5fd9a8feb75a4b5894c241777f519d4e, type: 3}
     coreBlitPS: {fileID: 4800000, guid: 93446b5c5339d4f00b85c159e1159b7c, type: 3}
     coreBlitColorAndDepthPS: {fileID: 4800000, guid: d104b2fc1ca6445babb8e90b0758136b, type: 3}
@@ -79,7 +83,7 @@ MonoBehaviour:
     m_Bits: 1079
   m_TransparentLayerMask:
     serializedVersion: 2
-    m_Bits: 55
+    m_Bits: 311
   m_DefaultStencilState:
     overrideStencilState: 0
     stencilReference: 0
@@ -92,8 +96,6 @@ MonoBehaviour:
   m_DepthPrimingMode: 0
   m_CopyDepthMode: 0
   m_AccurateGbufferNormals: 0
-  m_ClusteredRendering: 0
-  m_TileSize: 32
   m_IntermediateTextureMode: 1
 --- !u!114 &5356184961483977060
 MonoBehaviour:
@@ -119,6 +121,9 @@ MonoBehaviour:
       PassNames: []
     overrideMaterial: {fileID: 0}
     overrideMaterialPassIndex: 0
+    overrideShader: {fileID: 0}
+    overrideShaderPassIndex: 0
+    overrideMode: 1
     overrideDepthState: 0
     depthCompareFunction: 4
     enableWrite: 1
@@ -158,6 +163,9 @@ MonoBehaviour:
       PassNames: []
     overrideMaterial: {fileID: 0}
     overrideMaterialPassIndex: 0
+    overrideShader: {fileID: 0}
+    overrideShaderPassIndex: 0
+    overrideMode: 1
     overrideDepthState: 0
     depthCompareFunction: 4
     enableWrite: 1

--- a/Packages/Netherlands3D/WebServiceReader/Runtime/Scripts/Layer/WMSImageLayer.cs
+++ b/Packages/Netherlands3D/WebServiceReader/Runtime/Scripts/Layer/WMSImageLayer.cs
@@ -100,7 +100,7 @@ namespace Netherlands3D.Geoservice
             url = url.Replace("{Xmax}", (tileChange.X+tileSize).ToString());
             url = url.Replace("{Ymax}", (tileChange.Y + tileSize).ToString());
             
-            var webRequest = UnityWebRequestTexture.GetTexture(url);
+            var webRequest = UnityWebRequestTexture.GetTexture(url, compressLoadedTextures == false);
             tiles[tileKey].runningWebRequest = webRequest;
             yield return webRequest.SendWebRequest();
 

--- a/Packages/Netherlands3D/WebServiceReader/Runtime/Scripts/WMSReader/WMSHandler.cs
+++ b/Packages/Netherlands3D/WebServiceReader/Runtime/Scripts/WMSReader/WMSHandler.cs
@@ -55,7 +55,7 @@ public class WMSHandler : MonoBehaviour
 
     public IEnumerator DownloadImage(string mediaURL, ObjectEvent imageEvent)
     {
-        UnityWebRequest request = UnityWebRequestTexture.GetTexture(mediaURL);
+        UnityWebRequest request = UnityWebRequestTexture.GetTexture(mediaURL, true);
         yield return request.SendWebRequest();
         if (request.result == UnityWebRequest.Result.ConnectionError || request.result == UnityWebRequest.Result.ProtocolError)
         {
@@ -147,7 +147,7 @@ public class WMSHandler : MonoBehaviour
     }
     private IEnumerator GetLegendImage(string legendUrl)
     {
-        UnityWebRequest request = UnityWebRequestTexture.GetTexture(legendUrl);
+        UnityWebRequest request = UnityWebRequestTexture.GetTexture(legendUrl, true);
         yield return request.SendWebRequest();
         if (request.result == UnityWebRequest.Result.ConnectionError || request.result == UnityWebRequest.Result.ProtocolError)
         {


### PR DESCRIPTION
The GetTexture method of the UnityWebRequestTexture class has an optional flag that ensures a texture's bytes cannot be read, conserving memory because the image is not unpacked.

In the WMSImageLayer is an option to compress an image; this does need the texture to be readable and a special condition has been introduced to optimize the download when it is possible.