### PR TITLE
Ensure line-endings are always LF

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# For more information: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*.cs]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
When loading the project, I saw a warning that some files had mixed line-endings. EditorConfig files as recognized by most IDEs. By adding one that prescribes the line ending to be LF for all C# files, this should help contributors in keeping that part clean.