### PR TITLE
Cleaned up AddressSearch and made it more interoperable

### DIFF
--- a/Packages/Netherlands3D/AddressSearch/README.md
+++ b/Packages/Netherlands3D/AddressSearch/README.md
@@ -1,0 +1,54 @@
+﻿Address Search
+==============
+
+This package provides an auto-suggest Dropdown UI element. With this, the building associated with an address 
+can be found, and its BAG id returned using an event.
+
+When the option to move the camera is enabled, it will also move the Camera to a location matching the Coordinates 
+for the given object and tilt the Camera towards it.
+
+Usage
+-----
+
+Create a Canvas and InputSystem, and drop the SearchPanel prefab on. After that you can enter Play Mode and try it out 
+by typing 2 characters or more.
+
+The SearchPanel is restricted to search for addresses confined to a single city -by default: `Amsterdam`-. To change 
+this, see the next chapter on customizing.
+
+When an address is selected, the `GotBuilding` event is fired (see the section on events) and the presented list of BAG 
+identifiers can be used in your own code. Do note, by default the Camera will also move to that location; this can be 
+disabled using the `Move Camera` option.
+
+Customizing
+-----------
+
+The Search Panel contains a GameObject "SearchInput", whose Address Search component has all customizable properties, here are the most important ones and their effect:
+
+Search within City (string)
+: Restrict the search to the given name of a city.
+
+Characters needed (int)
+: Start searching after the given number of characters
+
+Move Camera (bool)
+: Whether to move the Camera to the position of the found address / object and tilt the camera down.
+
+Events
+------
+
+The Address Search component makes use of Scriptable Object events as provided by the Netherlands3D Core package.
+
+### Listening
+
+Clear Input (Trigger Event)
+: When this event is triggered, the input is cleared, the dropdown closed and it stops searching.
+
+### Emitting
+
+Toggle Clear Button (BoolEvent)
+: Whether to show or hide the Clear button.
+
+Got Building (String List Event)
+: When the user selects a suggestion, this event is fired with a list of strings representing the BAG identifiers 
+associated with that address.

--- a/Packages/Netherlands3D/AddressSearch/README.md.meta
+++ b/Packages/Netherlands3D/AddressSearch/README.md.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 49e02665f149432db62e68efcc8e4002
+timeCreated: 1681824722

--- a/Packages/Netherlands3D/AddressSearch/Runtime/Scripts/AddressSearch/AddressSearch.cs
+++ b/Packages/Netherlands3D/AddressSearch/Runtime/Scripts/AddressSearch/AddressSearch.cs
@@ -14,19 +14,30 @@ using SimpleJSON;
 public class AddressSearch : MonoBehaviour
 {
     private TMP_InputField searchInputField;
-    private Camera mainCam;
 
     [SerializeField]
-    [Tooltip("The WFS endpoint for retrieving BAG information (see: https://www.pdok.nl/geo-services/-/article/basisregistratie-adressen-en-gebouwen-ba-1)")]
+    [Tooltip("The WFS endpoint for retrieving BAG information, see: https://www.pdok.nl/geo-services/-/article/basisregistratie-adressen-en-gebouwen-ba-1")]
     private string bagWfsEndpoint = "https://service.pdok.nl/lv/bag/wfs/v2_0";
+    [SerializeField]
+    [Tooltip("The endpoint for retrieving suggestions when looking up addresses, see: https://www.pdok.nl/restful-api/-/article/pdok-locatieserver-1")]
+    private string locationSuggestionEndpoint = "https://geodata.nationaalgeoregister.nl/locatieserver/v3/suggest";
+    [Tooltip("The endpoint for looking up addresses, see: https://www.pdok.nl/restful-api/-/article/pdok-locatieserver-1")]
+    private string locationLookupEndpoint = "https://geodata.nationaalgeoregister.nl/locatieserver/v3/lookup";
     [SerializeField]
     private string searchWithinCity = "Amsterdam";
     [SerializeField]
     private int charactersNeededBeforeSearch = 2;
+    private GameObject resultsParent;
+
+    [Header("Camera Controls")]
+    [SerializeField]
+    private bool moveCamera = true;
+    [SerializeField]
+    private Camera mainCamera;
+    [SerializeField]
+    private Quaternion targetCameraRotation = Quaternion.Euler(45, 0, 0);
     [SerializeField]
     public AnimationCurve cameraMoveCurve;
-    [SerializeField]
-    private GameObject resultsParent;
 
     [Header("Listen to events")]
     [SerializeField]
@@ -46,7 +57,7 @@ public class AddressSearch : MonoBehaviour
 
     private void Start()
     {
-        mainCam = Camera.main;
+        if (!mainCamera) mainCamera = Camera.main;
 
         searchInputField = GetComponent<TMP_InputField>();
         searchInputField.onValueChanged.AddListener(delegate { GetSuggestions(searchInputField.text); });
@@ -64,57 +75,52 @@ public class AddressSearch : MonoBehaviour
 
     public void GetSuggestions(string textInput = "")
     {
-        var inputNotEmpty = (textInput != "");
         StopAllCoroutines();
 
-        if (inputNotEmpty)
-        {
-            if (textInput.Length > charactersNeededBeforeSearch)
-            {
-                if (toggleClearButton) toggleClearButton.InvokeStarted(true);
-                StartCoroutine(FindSearchSuggestions(textInput));
-            }
-            else
-            {
-                ClearSearchResults();
-            }
-        }
-        else
+        var isEmpty = textInput.Trim() == "";
+        if (isEmpty)
         {
             ClearSearchResults();
-            toggleClearButton.InvokeStarted(false);
+            if (toggleClearButton) toggleClearButton.InvokeStarted(false);
+            return;
         }
+
+        if (textInput.Length <= charactersNeededBeforeSearch)
+        {
+            ClearSearchResults();
+            return;
+        }
+
+        if (toggleClearButton) toggleClearButton.InvokeStarted(true);
+
+        StartCoroutine(FindSearchSuggestions(textInput));
     }
 
     IEnumerator FindSearchSuggestions(string searchTerm)
     {
         string urlEncodedSearchTerm = UnityWebRequest.EscapeURL(searchTerm);
-        string url = "https://geodata.nationaalgeoregister.nl/locatieserver/v3/suggest?q=" + urlEncodedSearchTerm + "%20and%20" + searchWithinCity + "%20and%20type:adres&rows=5".Replace(REPLACEMENT_STRING, urlEncodedSearchTerm);
+        string url =$"{locationSuggestionEndpoint}?q={urlEncodedSearchTerm}%20and%20{searchWithinCity}{"%20and%20type:adres&rows=5".Replace(REPLACEMENT_STRING, urlEncodedSearchTerm)}";
 
-        using (UnityWebRequest webRequest = UnityWebRequest.Get(url))
+        using UnityWebRequest webRequest = UnityWebRequest.Get(url);
+        yield return webRequest.SendWebRequest();
+
+        if (webRequest.result != UnityWebRequest.Result.Success)
         {
-            yield return webRequest.SendWebRequest();
+            Debug.LogWarning("Geen verbinding");
+            yield break;
+        }
 
-            if (webRequest.result != UnityWebRequest.Result.Success)
-            {
-                Debug.LogWarning("Geen verbinding");
-            }
-            else
-            {
-                ClearSearchResults();
+        ClearSearchResults();
 
-                string jsonStringResult = webRequest.downloadHandler.text;
-                var JSONobj = SimpleJSON.JSON.Parse(jsonStringResult);
-                var docs = JSONobj["response"]["docs"];
+        var jsonNode = JSON.Parse(webRequest.downloadHandler.text);
+        var results = jsonNode["response"]["docs"];
 
-                for (int i = 0; i < docs.Count; i++)
-                {
-                    var weergavenaam = docs[i]["weergavenaam"];
-                    var ID = docs[i]["id"];
+        for (int i = 0; i < results.Count; i++)
+        {
+            var ID = results[i]["id"];
+            var label = results[i]["weergavenaam"];
 
-                    GenerateResultItem(weergavenaam, ID);
-                }
-            }
+            GenerateResultItem(ID, label);
         }
     }
 
@@ -122,36 +128,35 @@ public class AddressSearch : MonoBehaviour
     {
         foreach (Transform child in resultsParent.transform)
         {
-            GameObject.Destroy(child.gameObject);
+            Destroy(child.gameObject);
         }
     }
 
-    private void GenerateResultItem(string weergavenaam, string ID)
+    private void GenerateResultItem(string ID, string label)
     {
-        GameObject NewObj = new GameObject();
-        NewObj.name = weergavenaam;
+        GameObject suggestion = new GameObject { name = label };
 
-        RectTransform rt = NewObj.AddComponent<RectTransform>();
+        RectTransform rt = suggestion.AddComponent<RectTransform>();
         rt.SetParent(resultsParent.transform);
         rt.localScale = new Vector3(1, 1, 1);
         rt.sizeDelta = new Vector2(160, 10);
 
-        NewObj.SetActive(true);
+        suggestion.SetActive(true);
 
-        TextMeshProUGUI tmpComp = NewObj.AddComponent<TextMeshProUGUI>();
-        tmpComp.color = Color.black;
-        tmpComp.fontSize = 10;
-        tmpComp.text = weergavenaam;
-        tmpComp.margin = new Vector4(10, 10, 10, 10);
+        TextMeshProUGUI textObject = suggestion.AddComponent<TextMeshProUGUI>();
+        textObject.color = Color.black;
+        textObject.fontSize = 10;
+        textObject.text = label;
+        textObject.margin = new Vector4(10, 10, 10, 10);
 
-        Button btnComp = NewObj.AddComponent<Button>();
-        btnComp.onClick.AddListener(delegate { GeoDataLookup(ID, weergavenaam); });
+        Button buttonObject = suggestion.AddComponent<Button>();
+        buttonObject.onClick.AddListener(delegate { GeoDataLookup(ID, label); });
     }
 
-    void GeoDataLookup(string ID, string weergavenaam)
+    private void GeoDataLookup(string ID, string label)
     {
         searchInputField.onValueChanged.RemoveAllListeners();
-        searchInputField.text = weergavenaam;
+        searchInputField.text = label;
         StartCoroutine(GeoDataLookupRoutine(ID));
         ClearSearchResults();
         searchInputField.onValueChanged.AddListener(delegate { GetSuggestions(searchInputField.text); });
@@ -159,35 +164,32 @@ public class AddressSearch : MonoBehaviour
 
     IEnumerator GeoDataLookupRoutine(string ID)
     {
-        string url = "https://geodata.nationaalgeoregister.nl/locatieserver/v3/lookup?id=" + ID;
-        using (UnityWebRequest webRequest = UnityWebRequest.Get(url))
+        string url = $"{locationLookupEndpoint}?id={ID}";
+        using UnityWebRequest webRequest = UnityWebRequest.Get(url);
+        yield return webRequest.SendWebRequest();
+
+        if (webRequest.result != UnityWebRequest.Result.Success)
         {
-            yield return webRequest.SendWebRequest();
-
-            if (webRequest.result != UnityWebRequest.Result.Success)
-            {
-                Debug.LogWarning("Geen verbinding");
-            }
-            else
-            {
-                string jsonStringResult = webRequest.downloadHandler.text;
-                var JSONobj = SimpleJSON.JSON.Parse(jsonStringResult);
-                var docs = JSONobj["response"]["docs"];
-
-                string centroid = docs[0]["centroide_ll"];
-                string verblijfsobject_id = docs[0]["adresseerbaarobject_id"];
-
-                Vector3 targetLocation = ExtractUnityLocation(ref centroid);
-                var targetPos = new Vector3((targetLocation.x), 300, (targetLocation.z - 300));
-                var targetRot = Quaternion.Euler(45, 0, 0);
-
-                StartCoroutine(LerpCamera(mainCam.gameObject, targetPos, targetRot, 2));
-                yield return new WaitForSeconds(2);
-                StartCoroutine(GetBAGID(verblijfsobject_id));
-            }
+            Debug.LogWarning("Geen verbinding");
+            yield break;
         }
 
-        yield return null;
+        var jsonNode = JSON.Parse(webRequest.downloadHandler.text);
+        var results = jsonNode["response"]["docs"];
+
+        string centroid = results[0]["centroide_ll"];
+        string residentialObjectID = results[0]["adresseerbaarobject_id"];
+
+        if (moveCamera)
+        {
+            Vector3 targetLocation = ExtractUnityLocation(ref centroid);
+            var targetPos = new Vector3(targetLocation.x, 300, targetLocation.z - 300);
+
+            StartCoroutine(LerpCamera(mainCamera.gameObject, targetPos, targetCameraRotation, 2));
+            yield return new WaitForSeconds(2);
+        }
+
+        StartCoroutine(GetBAGID(residentialObjectID));
     }
 
     private static Vector3 ExtractUnityLocation(ref string locationData)
@@ -198,8 +200,7 @@ public class AddressSearch : MonoBehaviour
         double.TryParse(lonLat[0], NumberStyles.Any, CultureInfo.InvariantCulture, out double lon);
         double.TryParse(lonLat[1], NumberStyles.Any, CultureInfo.InvariantCulture, out double lat);
 
-        Vector3 unityLocation = CoordConvert.WGS84toUnity(lon, lat);
-        return unityLocation;
+        return CoordConvert.WGS84toUnity(lon, lat);
     }
 
     IEnumerator LerpCamera(GameObject targetObj, Vector3 endPos, Quaternion endRot, float duration)

--- a/Packages/Netherlands3D/AddressSearch/Runtime/Scripts/AddressSearch/AddressSearch.cs
+++ b/Packages/Netherlands3D/AddressSearch/Runtime/Scripts/AddressSearch/AddressSearch.cs
@@ -155,7 +155,6 @@ public class AddressSearch : MonoBehaviour
         StartCoroutine(GeoDataLookupRoutine(ID));
         ClearSearchResults();
         searchInputField.onValueChanged.AddListener(delegate { GetSuggestions(searchInputField.text); });
-
     }
 
     IEnumerator GeoDataLookupRoutine(string ID)
@@ -187,6 +186,7 @@ public class AddressSearch : MonoBehaviour
                 StartCoroutine(GetBAGID(verblijfsobject_id));
             }
         }
+
         yield return null;
     }
 
@@ -214,6 +214,7 @@ public class AddressSearch : MonoBehaviour
             t += Time.deltaTime;
             yield return null;
         }
+
         targetObj.transform.position = endPos;
     }
 
@@ -233,13 +234,12 @@ public class AddressSearch : MonoBehaviour
         JSONNode jsonNode = JSON.Parse(webRequest.downloadHandler.text);
         JSONNode bagId = jsonNode["features"][0]["properties"]["pandidentificatie"];
 
-        #if UNITY_EDITOR
+#if UNITY_EDITOR
         Debug.Log($"BAG ID: {bagId}");
-        #endif
+#endif
 
-        List<string> bagIDs = new List<string> {bagId};
+        List<string> bagIDs = new List<string> { bagId };
 
         if (gotBuilding) gotBuilding.InvokeStarted(bagIDs);
     }
-
 }

--- a/Packages/Netherlands3D/AddressSearch/Runtime/Scripts/AddressSearch/AddressSearch.cs
+++ b/Packages/Netherlands3D/AddressSearch/Runtime/Scripts/AddressSearch/AddressSearch.cs
@@ -21,12 +21,14 @@ public class AddressSearch : MonoBehaviour
     [SerializeField]
     [Tooltip("The endpoint for retrieving suggestions when looking up addresses, see: https://www.pdok.nl/restful-api/-/article/pdok-locatieserver-1")]
     private string locationSuggestionEndpoint = "https://geodata.nationaalgeoregister.nl/locatieserver/v3/suggest";
+    [SerializeField]
     [Tooltip("The endpoint for looking up addresses, see: https://www.pdok.nl/restful-api/-/article/pdok-locatieserver-1")]
     private string locationLookupEndpoint = "https://geodata.nationaalgeoregister.nl/locatieserver/v3/lookup";
     [SerializeField]
     private string searchWithinCity = "Amsterdam";
     [SerializeField]
     private int charactersNeededBeforeSearch = 2;
+    [SerializeField]
     private GameObject resultsParent;
 
     [Header("Camera Controls")]
@@ -128,7 +130,7 @@ public class AddressSearch : MonoBehaviour
     {
         foreach (Transform child in resultsParent.transform)
         {
-            Destroy(child.gameObject);
+            GameObject.Destroy(child.gameObject);
         }
     }
 
@@ -155,11 +157,9 @@ public class AddressSearch : MonoBehaviour
 
     private void GeoDataLookup(string ID, string label)
     {
-        searchInputField.onValueChanged.RemoveAllListeners();
-        searchInputField.text = label;
+        searchInputField.SetTextWithoutNotify(label);
         StartCoroutine(GeoDataLookupRoutine(ID));
         ClearSearchResults();
-        searchInputField.onValueChanged.AddListener(delegate { GetSuggestions(searchInputField.text); });
     }
 
     IEnumerator GeoDataLookupRoutine(string ID)


### PR DESCRIPTION
Update AddressSearch package in preparation for better re-use. In this PR, I have extracted various magic strings into properties to enable users more control on whether to use camera movement or query a different WMS. This will also reduce cyclomatic complexity by using more early returns and cleans up the API a bit.

More improvements here can be to completely remove or extract camera handling because that should be more of an implementation detail and would remove the dependency on CoordConvert. In addition, I see a GameObject being instantiated and I wonder why this is not a prefab?

A README explaining the package's function and how to use it is also included in this PR