### PR TITLE
Added option to add a query parameter in a dataset path (url).

### DIFF
--- a/Packages/Netherlands3D/Core/Runtime/Scripts/TileSystem/BinaryMeshLayer.cs
+++ b/Packages/Netherlands3D/Core/Runtime/Scripts/TileSystem/BinaryMeshLayer.cs
@@ -90,17 +90,17 @@ namespace Netherlands3D.TileSystem
             string url = Datasets[index].path;
             if (Datasets[index].path.StartsWith("https://") || Datasets[index].path.StartsWith("file://"))
             {
-                url = Datasets[index].path;
+#if !UNITY_EDITOR && UNITY_WEBGL
+			    if(brotliCompressedExtention.Length>0)
+				    Datasets[index].path += brotliCompressedExtention;
+#endif
+                url = Datasets[index].url;
             }
 
             url = url.ReplaceXY(tileChange.X, tileChange.Y);
 
             //On WebGL we request brotli encoded files instead. We might want to base this on browser support.
 
-#if !UNITY_EDITOR && UNITY_WEBGL
-			if(brotliCompressedExtention.Length>0)
-				url += brotliCompressedExtention;
-#endif
 
             var webRequest = UnityWebRequest.Get(url);
 #if !UNITY_EDITOR && UNITY_WEBGL && ADD_BROTLI_ACCEPT_ENCODING_HEADER

--- a/Packages/Netherlands3D/Core/Runtime/Scripts/TileSystem/TileHandler.cs
+++ b/Packages/Netherlands3D/Core/Runtime/Scripts/TileSystem/TileHandler.cs
@@ -691,10 +691,20 @@ namespace Netherlands3D.TileSystem
         public string Description;
         public string geoLOD;
         public string path;
+        public string pathQuery;
         public float maximumDistance;
         [HideInInspector]
         public float maximumDistanceSquared;
         public bool enabled = true;
+
+
+        public string url
+        {
+            get
+            {
+                return path + pathQuery;
+            }
+        }
     }
 
     public class Tile


### PR DESCRIPTION
This will allow for example an azure sas token, without appending the .br file extension after the query, but after the resource path.