### PR TITLE
Add dotnet-format linting to Github Actions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,9 +5,12 @@ root = true
 
 # Unix-style newlines with a newline ending every file
 [*.cs]
-end_of_line = lf
+end_of_line = crlf
 insert_final_newline = true
 trim_trailing_whitespace = true
 charset = utf-8
 indent_style = space
 indent_size = 4
+
+csharp_indent_braces=false
+csharp_indent_block_contents=true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,5 +24,6 @@ jobs:
     - name: Run dotnet format
       uses: xt0rted/dotnet-format@v1
       with:
-        only-changed-files: "true"
+# enable again in the final version; but now nothing is checked
+#        only-changed-files: "true"
         action: "check"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,17 +13,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
-    - name: Add dotnet-format problem matcher
-      uses: xt0rted/dotnet-format-problem-matcher@v1
-
-    - name: Restore dotnet tools
-      uses: xt0rted/dotnet-tool-restore@v1
-
-    - name: Run dotnet format
-      uses: xt0rted/dotnet-format@v1
+    - name: Install dotnet
+      uses: actions/setup-dotnet@v3
       with:
-# enable again in the final version; but now nothing is checked
-#        only-changed-files: "true"
-        action: "check"
+        dotnet-version: '3.1.x'
+
+    - name: Run dotnet-format
+      uses: zyactions/dotnet-format@v1
+      with:
+        workspace: Netherlands3D.sln
+        verify-no-changes: true
+        implicit-restore: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+﻿on:
+  pull_request:
+  # Allow manually triggering the workflow.
+  workflow_dispatch:
+name: Continuous Integration
+
+permissions:
+  pull-requests: read
+  
+jobs:
+  lint:
+    name: Check code-style using dotnet-format
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v2
+
+    - name: Add dotnet-format problem matcher
+      uses: xt0rted/dotnet-format-problem-matcher@v1
+
+    - name: Restore dotnet tools
+      uses: xt0rted/dotnet-tool-restore@v1
+
+    - name: Run dotnet format
+      uses: xt0rted/dotnet-format@v1
+      with:
+        only-changed-files: "true"
+        action: "check"


### PR DESCRIPTION
As a point of discussion and proof that it works as expected; I have added a Github action that lints this PR using dotnet-format in combination with https://github.com/marketplace/actions/dotnet-format