### PR TITLE
WebGL won't build due to ASM def

### DIFF
--- a/Packages/Netherlands3D/Events/Editor/Scripts/eu.netherlands3d.event-system.Editor.asmdef
+++ b/Packages/Netherlands3D/Events/Editor/Scripts/eu.netherlands3d.event-system.Editor.asmdef
@@ -4,7 +4,9 @@
     "references": [
         "GUID:6fc4e9e40fe9cfd41bc3559197fc47b1"
     ],
-    "includePlatforms": [],
+    "includePlatforms": [
+        "Editor"
+    ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,

--- a/Packages/Netherlands3D/package.json
+++ b/Packages/Netherlands3D/package.json
@@ -138,6 +138,6 @@
     "com.unity.nuget.newtonsoft-json": "3.1.0",
     "com.unity.meshopt.decompress": "0.1.0-preview.5",
     "eu.netherlands3d.gltfast": "5.0.3",
-    "eu.netherlands3d.coordinates": "1.0.0"
+    "eu.netherlands3d.coordinates": "1.0.1"
   }
 }

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -211,7 +211,7 @@
       }
     },
     "eu.netherlands3d.coordinates": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "depth": 1,
       "source": "registry",
       "dependencies": {},
@@ -240,7 +240,7 @@
         "com.unity.nuget.newtonsoft-json": "3.1.0",
         "com.unity.meshopt.decompress": "0.1.0-preview.5",
         "eu.netherlands3d.gltfast": "5.0.3",
-        "eu.netherlands3d.coordinates": "1.0.0"
+        "eu.netherlands3d.coordinates": "1.0.1"
       }
     },
     "nl.netherlands3d.authentication": {


### PR DESCRIPTION
The editor ASM def had all platforms set as targets, but due to the editor-specific stuff in it only the editor should be the target platform. While extracting the events package, only in-editor testing was done, and thus it was missed that the build now broke.